### PR TITLE
fix: models screenshot in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm run dev
 
 Ollami have a built in library of available models that can be downloaded and run locally.
 
-![Ollami](https://raw.githubusercontent.com/aetaix/ollami/main/static/img/models.png)
+![Ollami](https://raw.githubusercontent.com/aetaix/ollami/main/static/img/Models.png)
 
 Of course, take the time to explore the different models available and choose the one that best suits your needs.
 


### PR DESCRIPTION
Just fixing wrong path to the `Models.png` image 
<img width="888" height="344" alt="image" src="https://github.com/user-attachments/assets/5ce0d347-b2cd-43f3-ae4a-3d9aa9a50601" />
